### PR TITLE
style fixes - Id members should be ID

### DIFF
--- a/ohdear/check.go
+++ b/ohdear/check.go
@@ -23,7 +23,7 @@ var CheckTypes = []string{
 }
 
 type Check struct {
-	Id      int    `json:"id,omitempty"`
+	ID      int    `json:"id,omitempty"`
 	Type    string `json:"type,omitempty"`
 	Enabled bool   `json:"enabled,omitempty"`
 }
@@ -33,11 +33,11 @@ type CheckService struct {
 }
 
 func (c *CheckService) EnableCheck(check *Check) (*http.Response, error) {
-	return c.performCheckAction(check.Id, "enable")
+	return c.performCheckAction(check.ID, "enable")
 }
 
 func (c *CheckService) DisableCheck(check *Check) (*http.Response, error) {
-	return c.performCheckAction(check.Id, "disable")
+	return c.performCheckAction(check.ID, "disable")
 }
 
 func (c *CheckService) performCheckAction(id int, lifecycleAction string) (*http.Response, error) {

--- a/ohdear/check_test.go
+++ b/ohdear/check_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Check", func() {
 		It("Should return a 204", func() {
 
 			check := &Check{
-				Id: 42,
+				ID: 42,
 			}
 
 			gock.New("http://test.org").
@@ -51,7 +51,7 @@ var _ = Describe("Check", func() {
 		It("Should return a 204", func() {
 
 			check := &Check{
-				Id: 42,
+				ID: 42,
 			}
 
 			gock.New("http://test.org").

--- a/ohdear/site.go
+++ b/ohdear/site.go
@@ -9,9 +9,9 @@ import (
 
 // Site represents an OhDear Site resource
 type Site struct {
-	Id                    int     `json:"id,omitempty"`
+	ID                    int     `json:"id,omitempty"`
 	Url                   string  `json:"url,omitempty"`
-	TeamId                int     `json:"team_id,omitempty"`
+	TeamID                int     `json:"team_id,omitempty"`
 	LatestRunDate         string  `json:"latest_run_date,omitempty"`
 	SummarizedCheckResult string  `json:"summarized_check_result,omitempty"`
 	CreatedAt             string  `json:"created_at,omitempty"`

--- a/ohdear/site_test.go
+++ b/ohdear/site_test.go
@@ -28,17 +28,17 @@ var _ = Describe("Site", func() {
 
 			sites := []Site{
 				Site{
-					Id:     1,
+					ID:     1,
 					Url:    "http://foobar.com",
-					TeamId: 170,
+					TeamID: 170,
 					Checks: []Check{
 						Check{
-							Id:      1,
+							ID:      1,
 							Type:    UptimeCheck,
 							Enabled: true,
 						},
 						Check{
-							Id:      1,
+							ID:      1,
 							Type:    BrokenLinksCheck,
 							Enabled: true,
 						},
@@ -69,17 +69,17 @@ var _ = Describe("Site", func() {
 		It("Should get the site by ID", func() {
 
 			siteData := &Site{
-				Id:     1,
+				ID:     1,
 				Url:    "http://foobar.com",
-				TeamId: 170,
+				TeamID: 170,
 				Checks: []Check{
 					Check{
-						Id:      1,
+						ID:      1,
 						Type:    UptimeCheck,
 						Enabled: true,
 					},
 					Check{
-						Id:      1,
+						ID:      1,
 						Type:    BrokenLinksCheck,
 						Enabled: true,
 					},
@@ -108,7 +108,7 @@ var _ = Describe("Site", func() {
 		It("should return a new site", func() {
 			site := &Site{
 				Url:    "http://foobar.com",
-				TeamId: 170,
+				TeamID: 170,
 				Checks: []Check{
 					Check{
 						Type: UptimeCheck,
@@ -120,17 +120,17 @@ var _ = Describe("Site", func() {
 			}
 
 			responseSite := &Site{
-				Id:     1,
+				ID:     1,
 				Url:    "http://foobar.com",
-				TeamId: 170,
+				TeamID: 170,
 				Checks: []Check{
 					Check{
-						Id:      1,
+						ID:      1,
 						Type:    UptimeCheck,
 						Enabled: true,
 					},
 					Check{
-						Id:      2,
+						ID:      2,
 						Type:    BrokenLinksCheck,
 						Enabled: true,
 					},
@@ -147,9 +147,9 @@ var _ = Describe("Site", func() {
 			site, _, err := client.SiteService.CreateSite(site)
 
 			Expect(err).To(BeNil())
-			Expect(site.Id).To(Equal(responseSite.Id))
+			Expect(site.ID).To(Equal(responseSite.ID))
 			Expect(site.Url).To(Equal(responseSite.Url))
-			Expect(site.TeamId).To(Equal(responseSite.TeamId))
+			Expect(site.TeamID).To(Equal(responseSite.TeamID))
 			Expect(len(site.Checks)).To(Equal(len(responseSite.Checks)))
 			Expect(gock.IsDone()).To(BeTrue())
 		})
@@ -163,14 +163,14 @@ var _ = Describe("Site", func() {
 
 		It("should delete the specified site", func() {
 			site := &Site{
-				Id: 170,
+				ID: 170,
 			}
 
 			gock.New("http://test.org").
 				Delete("/api/sites/170").
 				Reply(204)
 
-			resp, err := client.SiteService.DeleteSite(site.Id)
+			resp, err := client.SiteService.DeleteSite(site.ID)
 
 			Expect(err).To(BeNil())
 			Expect(gock.IsDone()).To(BeTrue())

--- a/ohdear/team.go
+++ b/ohdear/team.go
@@ -26,7 +26,7 @@ type TeamService struct {
 
 // ListTeams hits the `me` API endpoint and returns a list of teams
 func (t *TeamService) ListTeams() ([]Team, *http.Response, error) {
-	req, err := t.client.NewRequest("GET", "/api/me?include=teams", nil)
+	req, err := t.client.NewRequest("GET", "/api/me", nil)
 
 	if err != nil {
 		return nil, nil, err
@@ -35,6 +35,10 @@ func (t *TeamService) ListTeams() ([]Team, *http.Response, error) {
 	var userinfo = &UserInfo{}
 
 	resp, err := t.client.do(req, userinfo)
+	if err != nil {
+		log.Fatalf("Error retrieving teams from OhDear: %s", err)
+	}
+
 	if resp.StatusCode >= 300 {
 		log.Errorf("Error Retrieving teams from OhDear: %v", err.Error)
 		return nil, resp, err


### PR DESCRIPTION
Just some minor style fixes here - my linting tool tells me `Id` struct members should be `ID` - same for `FooId` => `FooID` - so I've implemented this here.