### PR TITLE
mark module as deprecated

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
       - uses: actions/cache@v2
         with:
           path: ~/go/pkg/mod

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - whitespace
     - goimports
     - gofmt
+    - gosec
 
 linters-settings:
   gocyclo:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,12 +14,8 @@ linters-settings:
   goimports:
     local-prefixes: github.com/articulate/ohdear-sdk
   gosimple:
-    go: "1.16"
+    go: "1.17"
   staticcheck:
-    go: "1.16"
+    go: "1.17"
   unused:
-    go: "1.16"
-
-issues:
-  exclude:
-    - exported (method|function|type|const) (.+) should have comment \(or a comment on this block\) or be unexported
+    go: "1.17"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: no replacement provided
 module github.com/articulate/ohdear-sdk
 
 go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/articulate/ohdear-sdk
 
-go 1.16
+go 1.17
 
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
@@ -21,4 +21,11 @@ require (
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/h2non/gock.v1 v1.0.11
 	gopkg.in/yaml.v2 v2.2.2 // indirect
+)
+
+require (
+	github.com/hpcloud/tail v1.0.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	gopkg.in/fsnotify.v1 v1.4.7 // indirect
+	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 )

--- a/ohdear/check_test.go
+++ b/ohdear/check_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Check", func() {
 
 	const (
 		testBaseURL = "http://test.org"
-		testToken   = "foobarbazquux"
+		testToken   = "foobarbazquux" //nolint:gosec
 	)
 
 	var (

--- a/ohdear/client_test.go
+++ b/ohdear/client_test.go
@@ -15,7 +15,7 @@ var _ = Describe("./Client", func() {
 
 	const (
 		testBaseURL = "http://test.org"
-		testToken   = "foobarbazquux"
+		testToken   = "foobarbazquux" //nolint:gosec
 	)
 
 	var (

--- a/ohdear/site_test.go
+++ b/ohdear/site_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Site", func() {
 
 	const (
 		testBaseURL = "http://test.org"
-		testToken   = "foobarbazquux"
+		testToken   = "foobarbazquux" //nolint:gosec
 	)
 
 	var (

--- a/ohdear/team_test.go
+++ b/ohdear/team_test.go
@@ -12,7 +12,7 @@ var _ = Describe("Team", func() {
 
 	const (
 		testBaseURL = "http://test.org"
-		testToken   = "foobarbazquux"
+		testToken   = "foobarbazquux" //nolint:gosec
 	)
 
 	var (


### PR DESCRIPTION
This module hasn't been maintained that frequently. There are a handful of features in OhDear that are missing from here. We don't use OhDear frequently enough to keep up with these changes.

Internally we only use this module in our [Terraform provider](https://github.com/articulate/terraform-provider-ohdear). Rather than making changes to this module (and trying to encompass all of the API), we are going to implement a client in the provider with only what we need.